### PR TITLE
Stop marshalling word-level backtrace matrices to JavaScript

### DIFF
--- a/.yarn/versions/a705a8c4.yml
+++ b/.yarn/versions/a705a8c4.yml
@@ -1,0 +1,5 @@
+releases:
+  "@storyteller-platform/align": patch
+
+declined:
+  - "@storyteller-platform/web"

--- a/.yarn/versions/a705a8c4.yml
+++ b/.yarn/versions/a705a8c4.yml
@@ -1,5 +1,2 @@
 releases:
   "@storyteller-platform/align": patch
-
-declined:
-  - "@storyteller-platform/web"

--- a/libraries/align/src/errorAlign/cpp/edit_distance.cpp
+++ b/libraries/align/src/errorAlign/cpp/edit_distance.cpp
@@ -1,4 +1,5 @@
 #include <napi.h>
+#include <algorithm>
 #include <string>
 #include <vector>
 #include <cmath>
@@ -242,6 +243,101 @@ static Napi::Value ComputeErrorAlignDistanceMatrix(const Napi::CallbackInfo& inf
     return matrix_to_napi(env, score_matrix);
 }
 
+// --- Unambiguous word matches ------------------------------------------------
+//
+// Computes the same result as BacktraceGraph.getUnambiguousNodeMatches over a
+// word-level Levenshtein backtrace, without ever materializing the score or
+// backtrace matrices as JavaScript values. The graph used by the JavaScript
+// implementation is exactly the set of matrix cells reachable backwards from
+// the terminal cell by following backtrace operations, with each reachable
+// cell's incoming ("parent") operations given by that cell's op combination,
+// so a reachability sweep plus per-cell op inspection reproduces it.
+
+static Napi::Value ComputeUnambiguousWordMatches(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    auto ref = napi_to_string_vec(info[0]);
+    auto hyp = napi_to_string_vec(info[1]);
+
+    auto [score_matrix, backtrace_matrix] = compute_distance_matrix(ref, hyp, "levenshtein", true);
+    (void)score_matrix;
+
+    const int ref_dim = static_cast<int>(ref.size()) + 1;
+    const int hyp_dim = static_cast<int>(hyp.size()) + 1;
+
+    // Reachability sweep, in the same reverse topological order as
+    // BacktraceGraph.nodes (hyp descending, then ref descending). Every
+    // parent produced by an op has coordinates <= the current cell's in both
+    // dimensions, and strictly smaller in at least one, so parents are always
+    // marked before the sweep reaches them.
+    std::vector<uint8_t> reachable(static_cast<size_t>(hyp_dim) * ref_dim, 0);
+    auto at = [ref_dim](int i, int j) { return static_cast<size_t>(i) * ref_dim + j; };
+    reachable[at(hyp_dim - 1, ref_dim - 1)] = 1;
+
+    for (int i = hyp_dim - 1; i >= 0; --i) {
+        for (int j = ref_dim - 1; j >= 0; --j) {
+            if (!reachable[at(i, j)] || (i == 0 && j == 0)) continue;
+            const auto& ops = OP_TYPE_COMBO_MAP.at(backtrace_matrix[i][j]);
+            for (OpType op : ops) {
+                const int pi = (op != DELETE) ? i - 1 : i;
+                const int pj = (op != INSERT) ? j - 1 : j;
+                reachable[at(pi, pj)] = 1;
+            }
+        }
+    }
+
+    // Candidate matches are reachable cells whose only incoming op is MATCH.
+    // A candidate is unambiguous when it is the only reachable cell consuming
+    // its ref token (via MATCH/SUBSTITUTE/DELETE) and the only reachable cell
+    // consuming its hyp token (via MATCH/SUBSTITUTE/INSERT).
+    std::vector<int> ref_count(ref_dim, 0);
+    std::vector<int> hyp_count(hyp_dim, 0);
+    std::vector<std::pair<int, int>> candidates;
+
+    for (int i = 0; i < hyp_dim; ++i) {
+        for (int j = 0; j < ref_dim; ++j) {
+            if (!reachable[at(i, j)] || (i == 0 && j == 0)) continue;
+            const auto& ops = OP_TYPE_COMBO_MAP.at(backtrace_matrix[i][j]);
+
+            if (ops.size() == 1 && ops[0] == MATCH) {
+                candidates.emplace_back(i, j);
+            }
+
+            bool consumes_ref = false;
+            bool consumes_hyp = false;
+            for (OpType op : ops) {
+                if (op == MATCH || op == SUBSTITUTE) {
+                    consumes_ref = true;
+                    consumes_hyp = true;
+                } else if (op == DELETE) {
+                    consumes_ref = true;
+                } else if (op == INSERT) {
+                    consumes_hyp = true;
+                }
+            }
+            if (consumes_ref) ref_count[j]++;
+            if (consumes_hyp) hyp_count[i]++;
+        }
+    }
+
+    std::vector<std::pair<int, int>> matches;
+    for (const auto& [i, j] : candidates) {
+        if (ref_count[j] == 1 && hyp_count[i] == 1) {
+            matches.emplace_back(i - 1, j - 1);
+        }
+    }
+    std::sort(matches.begin(), matches.end(),
+              [](const auto& a, const auto& b) { return a.second < b.second; });
+
+    Napi::Array result = Napi::Array::New(env, matches.size());
+    for (size_t k = 0; k < matches.size(); ++k) {
+        Napi::Array pair = Napi::Array::New(env, 2);
+        pair.Set((uint32_t)0, Napi::Number::New(env, matches[k].first));
+        pair.Set((uint32_t)1, Napi::Number::New(env, matches[k].second));
+        result.Set((uint32_t)k, pair);
+    }
+    return result;
+}
+
 // --- Module init (called from module.cpp) ------------------------------------
 
 void InitEditDistance(Napi::Env env, Napi::Object exports) {
@@ -249,4 +345,6 @@ void InitEditDistance(Napi::Env env, Napi::Object exports) {
                 Napi::Function::New(env, ComputeLevenshteinDistanceMatrix));
     exports.Set("computeErrorAlignDistanceMatrix",
                 Napi::Function::New(env, ComputeErrorAlignDistanceMatrix));
+    exports.Set("computeUnambiguousWordMatches",
+                Napi::Function::New(env, ComputeUnambiguousWordMatches));
 }

--- a/libraries/align/src/errorAlign/errorAlign.ts
+++ b/libraries/align/src/errorAlign/errorAlign.ts
@@ -5,6 +5,7 @@ import { BacktraceGraph } from "./backtraceGraph.ts"
 import { type GraphMetadata, SubgraphMetadata } from "./graphMetadata.ts"
 import {
   computeLevenshteinDistanceMatrix,
+  computeUnambiguousWordMatches,
   errorAlignBeamSearch,
 } from "./native.ts"
 import { getAlignments } from "./pathToAlignment.ts"
@@ -117,13 +118,21 @@ function alignWithWordLevelPass(
   graphMetadata: GraphMetadata,
   beamSize: number,
 ) {
-  const { backtraceMatrix } = computeLevenshteinDistanceMatrix(
-    graphMetadata.refNorm,
-    graphMetadata.hypNorm,
-    true,
-  )
-  const backtraceGraph = new BacktraceGraph(backtraceMatrix)
-  const matchIndices = backtraceGraph.getUnambiguousNodeMatches()
+  let matchIndices: (readonly [number, number])[]
+  if (process.env["STORYTELLER_LEGACY_WORD_PASS"]) {
+    const { backtraceMatrix } = computeLevenshteinDistanceMatrix(
+      graphMetadata.refNorm,
+      graphMetadata.hypNorm,
+      true,
+    )
+    const backtraceGraph = new BacktraceGraph(backtraceMatrix)
+    matchIndices = backtraceGraph.getUnambiguousNodeMatches()
+  } else {
+    matchIndices = computeUnambiguousWordMatches(
+      graphMetadata.refNorm,
+      graphMetadata.hypNorm,
+    )
+  }
   // NOTE: We always add an artificial terminal match node to simplify subspan extraction.
   matchIndices.push([
     graphMetadata.hypNorm.length,

--- a/libraries/align/src/errorAlign/native.ts
+++ b/libraries/align/src/errorAlign/native.ts
@@ -19,6 +19,10 @@ const native = requireBinding(
     hyp: string | string[],
     backtrace: boolean,
   ): number[][] | { scoreMatrix: number[][]; backtraceMatrix: number[][] }
+  computeUnambiguousWordMatches(
+    ref: string | string[],
+    hyp: string | string[],
+  ): [number, number][]
   errorAlignBeamSearch(
     src: SubgraphMetadata,
     beamSize: number,
@@ -57,6 +61,20 @@ export function computeErrorAlignDistanceMatrix(
   backtrace = false,
 ): number[][] | { scoreMatrix: number[][]; backtraceMatrix: number[][] } {
   return native.computeErrorAlignDistanceMatrix(ref, hyp, backtrace)
+}
+
+/**
+ * Compute unambiguous word-level match indices between two token sequences.
+ *
+ * Equivalent to running computeLevenshteinDistanceMatrix with backtrace and
+ * BacktraceGraph.getUnambiguousNodeMatches over the result, but the matrices
+ * never cross the native boundary.
+ */
+export function computeUnambiguousWordMatches(
+  ref: string | string[],
+  hyp: string | string[],
+): [number, number][] {
+  return native.computeUnambiguousWordMatches(ref, hyp)
 }
 
 export function errorAlignBeamSearch(


### PR DESCRIPTION
I run storyteller with transcription offloaded to a whisper-server on a GPU box, so the alignment pass is the biggest piece of work my actual server (a Pi 5) does itself. The addon already computes the word level backtrace matrix in C++, but then both full matrices get marshalled across the NAPI boundary and walked in JS with BacktraceGraph, all to extract a short list of unambiguous match indices. For a typical chapter that's tens of millions of cells crossing the boundary to produce a few dozen numbers, plus a lot of GC churn from the marshalled arrays.

This adds computeUnambiguousWordMatches to the addon: same matrix computation as before, then a reachability sweep and per-cell op analysis that reproduces BacktraceGraph.getUnambiguousNodeMatches, returning only the match index pairs. The matrices never leave C++.

results:

- Ryzen 5900X (WSL2), Peter and Wendy fixture: 35s -> 13s (2.7x)
- Pi 5, a 13 hour audiobook with cached transcriptions: 198s -> 69s (2.9x)

Output is byte identical everywhere I could check: the align snapshot suite passes unchanged, errorAlign unit tests pass on both paths, and I diffed full alignment snapshots between the two paths on the 13 hour book on arm64, plus a determinism check across runs. I left the old JS path in behind STORYTELLER_LEGACY_WORD_PASS for easy comparison, happy to drop it if you'd rather not carry the flag.

## Testing

- align snapshot suite passes unchanged 
- errorAlign unit tests pass on both paths
- diffed full alignment snapshots between the two paths on the 13 hour book, byte identical, and ran the new path twice to check determinism
- built the addon with AddressSanitizer and ran edge cases (empty inputs, adversarial repeats) plus a 3000x3000 token workload through the new function. No findings, just the well known 24 byte openssl init leak inside node itself
- tested on x86_64 (WSL2, Ryzen 5900X) and arm64 (Pi 5)

You can A/B it yourself with STORYTELLER_LEGACY_WORD_PASS=1.
